### PR TITLE
Improve usability of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,21 @@ FROM php:7.4-cli
 # Arbeitsverzeichnis in Container
 WORKDIR /app
 
-# Kopiere Projektdateien in Container
-COPY . /app
-
 # Installiere erforderliche PHP-Erweiterungen und Abhängigkeiten
 RUN apt-get update && apt-get install -y \
     git \
     unzip \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-dev
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Kopiere erst nur die Dependencies ...
+COPY composer.json composer.lock .
+
+# ... um sie mit Composer zu installieren
+RUN composer install --no-dev
+
+# Kopiere Projektdateien in Container, nach den Dependencies. Verbessert Caching.
+COPY . .
+
+# Definiere Standard-Befehle
+ENTRYPOINT ["php"]
+CMD ["main.php"]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ Actually this php library can only handle one xml file passed to stdin.
 
 ## How To
 ### Docker
-If you want to use this little library as docker image so perform `docker build -t xpathgenerator .`.
 
-Now try to pass a xml file to the script using `cat your/file.xml | | docker run --rm -i xpathgenerator php main.php -
-`  
+If you want to use this little library as docker image so perfor
+
+```shell
+docker build -t xpathgenerator .
+```
+
+Now try to pass a xml file to the script using
+
+```shell
+cat your/file.xml | docker run --rm -i xpathgenerator
+``` 
 
 ### Local
 


### PR DESCRIPTION
This PR adds and entrypoint + cmd to the docker image, which allows us to  simplify this

```shell
docker run image php main.php
```

into this

```shell
docker run image
```

While I was at it, I also split some steps in the Dockerfile to improve caching. Composer packages are now installed before actually copying the source code. Now changed source code will not cause the install steps to re-run.

:)